### PR TITLE
Added error handling / reporting, and other basic utilities.

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -43,6 +43,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9a60d744a80c30fcb657dfe2c1b22bcb3e814c1a1e3674f32bf5820b570fbff"
+
+[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -895,9 +901,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0"
+checksum = "99e85c08494b21a9054e7fe1374a732aeadaff3980b6990b94bfd3a70f690005"
 
 [[package]]
 name = "libloading"
@@ -1274,6 +1280,17 @@ dependencies = [
  "sxd-document",
  "test-env-log",
  "uuid 0.5.1",
+]
+
+[[package]]
+name = "pact_matching_ffi"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "libc",
+ "pact_matching",
+ "thiserror",
+ "zeroize",
 ]
 
 [[package]]
@@ -2150,6 +2167,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b3d3d2ff68104100ab257bb6bb0cb26c901abe4bd4ba15961f3bf867924012"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca972988113b7715266f91250ddb98070d033c62a011fa0fcc57434a649310dd"
+dependencies = [
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
+ "syn 1.0.17",
+]
+
+[[package]]
 name = "thread-id"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2599,3 +2636,9 @@ dependencies = [
  "winapi 0.2.8",
  "winapi-build",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"

--- a/rust/pact_matching_ffi/Cargo.toml
+++ b/rust/pact_matching_ffi/Cargo.toml
@@ -3,7 +3,20 @@ name = "pact_matching_ffi"
 version = "0.1.0"
 authors = ["Andrew Lilley Brinker <abrinker@mitre.org>"]
 edition = "2018"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+description = "Pact matching interface for foreign languages."
+readme = "README.md"
+keywords = ["testing", "pact", "cdc", "mockserver"]
+license = "MIT"
+exclude = [
+    "*.iml"
+]
 
 [dependencies]
+anyhow = "1.0.28"
+libc = "0.2.69"
+zeroize = "1.1.0"
+thiserror = "1.0.15"
+pact_matching = { version = "0.5.11", path = "../pact_matching" }
+
+[lib]
+crate-type = ["cdylib", "staticlib", "rlib"]

--- a/rust/pact_matching_ffi/src/error/any_error.rs
+++ b/rust/pact_matching_ffi/src/error/any_error.rs
@@ -1,0 +1,26 @@
+//! Defines an alias for the type returned by `std::panic::catch_unwind`.
+
+use crate::error::error_msg::ErrorMsg;
+use std::any::Any;
+
+/// The error type returned by `std::panic::catch_unwind`.
+pub(crate) type AnyError = Box<dyn Any + Send + 'static>;
+
+/// An extension trait for extracting an error message out of an `AnyError`.
+pub(crate) trait ToErrorMsg {
+    fn to_error_msg(self) -> String;
+}
+
+impl ToErrorMsg for AnyError {
+    /// This works with an `AnyError` taken from `std::panic::catch_unwind`,
+    /// attempts to extract an error message out of it by constructing the
+    /// `ErrorMsg` type, and then converts that to a string, which is passed
+    /// to `update_last_error`.
+    ///
+    /// Note that if an error message can't be extracted from the `AnyError`,
+    /// there will still be an update to the `LAST_ERROR`, reporting that an
+    /// unknown error occurred.
+    fn to_error_msg(self) -> String {
+        ErrorMsg::from(self).to_string()
+    }
+}

--- a/rust/pact_matching_ffi/src/error/error_msg.rs
+++ b/rust/pact_matching_ffi/src/error/error_msg.rs
@@ -1,0 +1,31 @@
+//! Defines an error type representing the message extracted from `AnyError`.
+
+use crate::error::any_error::AnyError;
+
+/// An error message extracted from an `AnyError`.
+///
+/// This is part of the implement of the LAST_ERROR mechanism, which takes any `AnyError`,
+/// attempts to extract an `ErrorMsg` out of it, and then stores the resulting string
+/// (from the `ToString` impl implies by `Display`) as the LAST_ERROR message.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum ErrorMsg {
+    /// A successfully-extracted message.
+    #[error("{0}")]
+    Message(String),
+
+    /// Could not extract a message, so the error is unknown.
+    #[error("an unknown error occured")]
+    Unknown,
+}
+
+impl From<AnyError> for ErrorMsg {
+    fn from(other: AnyError) -> ErrorMsg {
+        if let Some(s) = other.downcast_ref::<String>() {
+            ErrorMsg::Message(s.clone())
+        } else if let Some(s) = other.downcast_ref::<&str>() {
+            ErrorMsg::Message(s.to_string())
+        } else {
+            ErrorMsg::Unknown
+        }
+    }
+}

--- a/rust/pact_matching_ffi/src/error/ffi.rs
+++ b/rust/pact_matching_ffi/src/error/ffi.rs
@@ -1,0 +1,47 @@
+//! The FFI functions exposed for getting the last error.
+
+use crate::error::last_error::get_error_msg;
+use crate::error::status::Status;
+use crate::util::write::write_to_c_buf;
+use libc::{c_char, c_int};
+use std::slice;
+
+/// Provide the error message from `LAST_ERROR` to the calling C code.
+///
+/// # Params
+///
+/// * `buffer`: a pointer to an array of `char` of sufficient length to hold the error message.
+/// * `length`: an int providing the length of the `buffer`.
+///
+/// # Return Codes
+///
+/// * The number of bytes written to the provided buffer, which may be zero if there is no last error.
+/// * `-1` if the provided buffer is a null pointer.
+/// * `-2` if the provided buffer length is too small for the error message.
+/// * `-3` if the write failed for some other reason.
+/// * `-4` if the error message had an interior NULL
+///
+/// # Notes
+///
+/// Note that this function zeroes out any excess in the provided buffer.
+#[no_mangle]
+pub extern "C" fn get_error_message(buffer: *mut c_char, length: c_int) -> c_int {
+    // Make sure the buffer isn't null.
+    if buffer.is_null() {
+        return Status::NullBuffer as c_int;
+    }
+
+    // Convert the buffer raw pointer into a byte slice.
+    let buffer = unsafe { slice::from_raw_parts_mut(buffer as *mut u8, length as usize) };
+
+    // Get the last error, possibly empty if there isn't one.
+    let last_err = get_error_msg().unwrap_or(String::new());
+
+    // Try to write the error to the buffer.
+    let status = match write_to_c_buf(&last_err, buffer) {
+        Ok(_) => Status::Success,
+        Err(err) => Status::from(err),
+    };
+
+    status as c_int
+}

--- a/rust/pact_matching_ffi/src/error/last_error.rs
+++ b/rust/pact_matching_ffi/src/error/last_error.rs
@@ -1,0 +1,24 @@
+//! The internal API for setting and getting the last error message.
+
+#![allow(dead_code)]
+
+use std::cell::RefCell;
+
+thread_local! {
+    /// The last error to have been reported by the FFI code.
+    static LAST_ERROR: RefCell<Option<String>> = RefCell::new(None);
+}
+
+/// Update the last error with a new error message.
+#[inline]
+pub(crate) fn set_error_msg(e: String) {
+    LAST_ERROR.with(|last| {
+        *last.borrow_mut() = Some(e);
+    });
+}
+
+/// Get the last error message if there is one.
+#[inline]
+pub(crate) fn get_error_msg() -> Option<String> {
+    LAST_ERROR.with(|last| last.borrow_mut().take())
+}

--- a/rust/pact_matching_ffi/src/error/mod.rs
+++ b/rust/pact_matching_ffi/src/error/mod.rs
@@ -1,0 +1,47 @@
+//! Tools for FFI error reporting and handling.
+//!
+//! This error handling system is based on the one described in the [unofficial Rust FFI book][book].
+//!
+//! # How It Works (User's Perspective)
+//!
+//! FFI code needs to be wrapped in `catch_unwind`, to make sure no panics propogate to the C code calling
+//! the FFI. The question then is what to do if an error occurs. The mechanism here is similar to the standard
+//! C `errno` pattern, and should be familiar and comfortable for C users of the FFI.
+//!
+//! The idea is that the FFI functions will return a sentinel value to indicate some error has occurred. If the
+//! function is returning a pointer, a null pointer is a sensible sentinel. If the function is returning an
+//! integer type, some sensible error-representing integers should be selected and documented for that function.
+//!
+//! If the C code sees the error sentinel, they then have the option of checking for the last error message
+//! using the `get_error_message` function provided in this module. This pulls the last error message string
+//! from a thread-local global variable called `LAST_ERROR`, and attempts to put it into a user-provided
+//! buffer. If the buffer is a null pointer, or not long enough, or there is no `LAST_ERROR` message, the
+//! `get_error_message` function returns an appropriate error sentinel value, which can be checked and handled
+//! by the C code.
+//!
+//! # How It Works (Crate Internal Perspective)
+//!
+//! All code used for the FFI operations needs to be wrapped in a `catch_unwind`, which captures panics and
+//! converts their messages into an error of the type `Box<dyn Any + Send + 'static>`. The error handling code
+//! then downcasts that to a string, which is stored in the `LAST_ERROR` global. When the C user requests the
+//! last error, that string is written to the buffer they provided if possible.
+//!
+//! What this means for user code is that errors in `catch_unwind` should be converted into panics with a useful
+//! error message so they can be handled by this mechanism.
+//!
+//! [book]: https://michael-f-bryan.github.io/rust-ffi-guide/errors/index.html "Better Error Handling chapter of the Unofficial Rust FFI book"
+
+#![allow(unused)]
+
+mod any_error;
+mod error_msg;
+mod ffi;
+mod last_error;
+mod panic;
+mod status;
+
+// Function for the C program to read the last error message.
+pub use crate::error::ffi::get_error_message;
+
+// Utility function for convenient panic-catching and error-reporting.
+pub(crate) use crate::error::panic::catch_panic;

--- a/rust/pact_matching_ffi/src/error/panic.rs
+++ b/rust/pact_matching_ffi/src/error/panic.rs
@@ -1,0 +1,33 @@
+//! An alternative to `std::panic::catch_unwind` which does error-reporting.
+
+use crate::error::any_error::ToErrorMsg;
+use crate::error::last_error::set_error_msg;
+use std::panic::{catch_unwind, UnwindSafe};
+
+/// Convenient panic-catching and reporting.
+///
+/// This wraps `std::panic::catch_unwind`, but enables you to write functions which return
+/// `Result<T, anyhow::Error>` and have those errors correctly reported out.
+pub(crate) fn catch_panic<T, F>(f: F) -> Option<T>
+where
+    F: FnOnce() -> Result<T, anyhow::Error> + UnwindSafe,
+{
+    // The return type is Result<Result<T, anyhow::Error>, AnyError>
+    let result = catch_unwind(f);
+
+    match result {
+        Ok(Ok(value)) => Some(value),
+        Ok(Err(err)) => {
+            // We have an `anyhow::Error`
+            let err = err.to_string();
+            set_error_msg(err);
+            None
+        }
+        Err(err) => {
+            // We have an `AnyError`
+            let err = err.to_error_msg();
+            set_error_msg(err);
+            None
+        }
+    }
+}

--- a/rust/pact_matching_ffi/src/error/status.rs
+++ b/rust/pact_matching_ffi/src/error/status.rs
@@ -1,0 +1,34 @@
+//! The possible status codes which error-FFI may return to the C caller.
+
+use crate::util::write::WriteBufError;
+
+/// The status code returned by `get_error_message` to the C caller.
+pub(crate) enum Status {
+    /// Writing the buffer succeeded.
+    ///
+    /// Note that because the entirety of the buffer is zeroized, there's
+    /// no need to indicate how many bytes were written.
+    Success = 0,
+
+    /// The buffer passed in was a null pointer.
+    NullBuffer = -1,
+
+    /// The buffer was too small for the error message.
+    BufferTooSmall = -2,
+
+    /// The error message failed to write to the buffer.
+    FailedWrite = -3,
+
+    /// The error message contained an interior null terminator.
+    InteriorNul = -4,
+}
+
+impl From<WriteBufError> for Status {
+    fn from(err: WriteBufError) -> Status {
+        match err {
+            WriteBufError::DstTooShort { .. } => Status::BufferTooSmall,
+            WriteBufError::FailedWrite(_) => Status::FailedWrite,
+            WriteBufError::InteriorNul(_) => Status::InteriorNul,
+        }
+    }
+}

--- a/rust/pact_matching_ffi/src/lib.rs
+++ b/rust/pact_matching_ffi/src/lib.rs
@@ -1,7 +1,9 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}
+//! A crate exposing the `pact_matching` API to other languages
+//! via a C Foreign Function Interface.
+
+#![warn(missing_docs)]
+#![warn(missing_debug_implementations)]
+#![warn(missing_copy_implementations)]
+
+pub mod error;
+pub(crate) mod util;

--- a/rust/pact_matching_ffi/src/util/ffi.rs
+++ b/rust/pact_matching_ffi/src/util/ffi.rs
@@ -1,0 +1,14 @@
+//! Provides a convenience macro for wrapping FFI code.
+
+#![allow(unused)]
+
+/// Makes sure FFI code is always wrapped in `catch_unwind` and sets its error.
+///
+/// This convenience macro is intended to make it easier to write _correct_ FFI code
+/// which catches panics before they cross the language boundary, and reports its error
+/// out for the C caller to read if they want.
+macro_rules! ffi {
+    ( op: $op:block, fail: $fail:block ) => {{
+        $crate::error::catch_panic(|| $op).unwrap_or($fail)
+    }};
+}

--- a/rust/pact_matching_ffi/src/util/mod.rs
+++ b/rust/pact_matching_ffi/src/util/mod.rs
@@ -1,0 +1,7 @@
+//! A collection of helper functions to make it easier to write the FFI code correctly
+//! and consistently.
+
+#[macro_use]
+pub(crate) mod ffi;
+pub(crate) mod ptr;
+pub(crate) mod write;

--- a/rust/pact_matching_ffi/src/util/ptr.rs
+++ b/rust/pact_matching_ffi/src/util/ptr.rs
@@ -1,0 +1,35 @@
+//! Utility functions for working with raw pointers.
+
+#![allow(unused)]
+
+use std::mem;
+use std::ptr;
+
+/// Get a raw pointer to a value on the heap.
+///
+/// Allocates the value on the heap by boxing it, and then gets a mutable raw pointer
+/// to the memory location, to pass to the C-side of the FFI boundary. It is then the
+/// responsibility of the C code to call the relevant FFI destructor function, which will
+/// re-construct a `Box` to the pointer, and then drop the `Box` to deallocate the memory.
+#[inline]
+pub(crate) fn raw_to<T>(value: T) -> *mut T {
+    Box::into_raw(Box::new(value))
+}
+
+/// Drop the value pointed to by a raw pointer.
+#[inline]
+pub(crate) fn drop_raw<T>(raw: *mut T) {
+    mem::drop(unsafe { Box::from_raw(raw) })
+}
+
+/// Get a constant null pointer to the given type.
+#[inline]
+pub(crate) fn null_to<T>() -> *const T {
+    ptr::null() as *const T
+}
+
+/// Get a mutable null pointer to the given type.
+#[inline]
+pub(crate) fn null_mut_to<T>() -> *mut T {
+    ptr::null_mut() as *mut T
+}

--- a/rust/pact_matching_ffi/src/util/write.rs
+++ b/rust/pact_matching_ffi/src/util/write.rs
@@ -1,0 +1,74 @@
+//! API for safely writing Rust `String`s into C strings.
+
+use std::ffi::{CString, NulError};
+use std::io::{self, Write};
+use zeroize::Zeroize;
+
+/// Write a string slice to a C buffer safely.
+///
+/// This performs a write, including the null terminator and performing zeroization of any
+/// excess in the destination buffer.
+pub(crate) fn write_to_c_buf(src: &str, dst: &mut [u8]) -> Result<(), WriteBufError> {
+    // Ensure the string has the null terminator.
+    let src = CString::new(src.as_bytes())?;
+    let src = src.as_bytes_with_nul();
+
+    // Make sure the destination buffer is big enough.
+    check_len(src, dst)?;
+
+    // Perform a zeroized write to the destination buffer.
+    dst.zeroized_write(src)?;
+
+    Ok(())
+}
+
+/// An error arising out of an attempted safe write to a C buffer.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum WriteBufError {
+    /// The destination buffer is too short.
+    #[error("destination buffer too short (needs {src_len} bytes, has {dst_len} bytes)")]
+    DstTooShort { src_len: usize, dst_len: usize },
+
+    /// The write failed.
+    #[error(transparent)]
+    FailedWrite(#[from] io::Error),
+
+    /// The string contained an interior null byte.
+    #[error(transparent)]
+    InteriorNul(#[from] NulError),
+}
+
+fn check_len(src: &[u8], dst: &[u8]) -> Result<(), WriteBufError> {
+    // make room for the null terminator.
+    let src_len = src.len();
+    let dst_len = dst.len();
+
+    if dst_len < src_len {
+        Err(WriteBufError::DstTooShort { src_len, dst_len })
+    } else {
+        Ok(())
+    }
+}
+
+/// A convenience trait extending `Write` to zeroize the remainder of the buffer.
+///
+/// Only implemented for `&mut [u8]`.
+trait ZeroizedWrite: Write {
+    // Because the write is zeroized, no length written is returned,
+    // as it will always be the full length of the buffer being written to.
+    fn zeroized_write(self, buf: &[u8]) -> io::Result<()>;
+}
+
+impl<'a> ZeroizedWrite for &'a mut [u8] {
+    fn zeroized_write<'b>(mut self, buf: &'b [u8]) -> io::Result<()> {
+        // Write the buffer.
+        self.write_all(buf)?;
+
+        // Check if there's a remainder and zeroize if there is.
+        if let Some(remainder) = self.get_mut(buf.len()..) {
+            remainder.iter_mut().zeroize();
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Closes #2 

This commit adds an error handling mechanism modelled after the
mechanism in `libgit2`, where errors (and panics, to avoid undefined
behavior by panicking across a language boundary) are captured and
written as messages to a `LAST_ERROR` value in thread-local storage.
Functions which error out in this way are expected to return some value
which indicates an error (a status code or a null pointer, commonly),
leaving the C code to get the last error message and (potentially)
handle the error.

This commit also adds in some utility functions, some of which are
needed for future additions (including basic pointer operations and an
FFI convenience macro) and some of which are needed currently
(specifically a safe mechanism for converting a Rust `String` into
a `CString` and writing it to a C buffer).

Another thing to note is that all FFI functions are expected to be
wrapped in the FFI-helper which ensures errors are captured and
reported properly, with the exception of the function to retrieve the
latest error itself. As such, the error-handling API must be
particularly scrutinized now and in the future to ensure it doesn't
leave open the possibility of cross-language panics.