### PR TITLE
Establish pact_matching_ffi logging mechanism

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -471,6 +471,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fern"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9a4820f0ccc8a7afd67c39a0f1a0f4b07ca1725164271a64939d7aeb9af065"
+dependencies = [
+ "log 0.4.8",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1287,7 +1296,9 @@ name = "pact_matching_ffi"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "fern",
  "libc",
+ "log 0.4.8",
  "pact_matching",
  "thiserror",
  "zeroize",

--- a/rust/pact_matching_ffi/Cargo.toml
+++ b/rust/pact_matching_ffi/Cargo.toml
@@ -12,11 +12,13 @@ exclude = [
 ]
 
 [dependencies]
+pact_matching = { version = "0.5.11", path = "../pact_matching" }
 anyhow = "1.0.28"
 libc = "0.2.69"
 zeroize = "1.1.0"
 thiserror = "1.0.15"
-pact_matching = { version = "0.5.11", path = "../pact_matching" }
+fern = "0.6.0"
+log = "0.4.8"
 
 [lib]
 crate-type = ["cdylib", "staticlib", "rlib"]

--- a/rust/pact_matching_ffi/rustfmt.toml
+++ b/rust/pact_matching_ffi/rustfmt.toml
@@ -1,0 +1,1 @@
+max_width = 74

--- a/rust/pact_matching_ffi/src/error/ffi.rs
+++ b/rust/pact_matching_ffi/src/error/ffi.rs
@@ -25,14 +25,19 @@ use std::slice;
 ///
 /// Note that this function zeroes out any excess in the provided buffer.
 #[no_mangle]
-pub extern "C" fn get_error_message(buffer: *mut c_char, length: c_int) -> c_int {
+pub extern "C" fn get_error_message(
+    buffer: *mut c_char,
+    length: c_int,
+) -> c_int {
     // Make sure the buffer isn't null.
     if buffer.is_null() {
         return Status::NullBuffer as c_int;
     }
 
     // Convert the buffer raw pointer into a byte slice.
-    let buffer = unsafe { slice::from_raw_parts_mut(buffer as *mut u8, length as usize) };
+    let buffer = unsafe {
+        slice::from_raw_parts_mut(buffer as *mut u8, length as usize)
+    };
 
     // Get the last error, possibly empty if there isn't one.
     let last_err = get_error_msg().unwrap_or(String::new());

--- a/rust/pact_matching_ffi/src/lib.rs
+++ b/rust/pact_matching_ffi/src/lib.rs
@@ -6,4 +6,5 @@
 #![warn(missing_copy_implementations)]
 
 pub mod error;
+pub mod log;
 pub(crate) mod util;

--- a/rust/pact_matching_ffi/src/log/ffi.rs
+++ b/rust/pact_matching_ffi/src/log/ffi.rs
@@ -1,0 +1,106 @@
+//! The public FFI functions for initializing, adding sinks to, and applying a logger.
+
+use crate::log::level_filter::LevelFilter;
+use crate::log::logger::{add_sink, apply_logger, set_logger};
+use crate::log::sink::Sink;
+use crate::log::status::Status;
+use fern::Dispatch;
+use libc::{c_char, c_int};
+use log::LevelFilter as LogLevelFilter;
+use std::convert::TryFrom;
+use std::ffi::CStr;
+
+// C API uses something like the pledge API to select write locations, including:
+//
+// * stdout
+// * stderr
+// * file w/ file path
+//
+// The general flow is:
+//
+// 1. Call `logger_init` to create a `Dispatch` struct.
+// 2. Call `logger_attach_sink` to add an additional sink, using bitflags to set the metadata.
+// 3. Call `logger_apply` to finalize the logger and enable logging to the configured sinks.
+//
+// Once `logger_apply` has been called, any additional calls to `logger_attach_sink` will fail
+// with an error indicating the logger has been applied already.
+//
+// ```
+// logger_init();
+//
+// int result = logger_attach_sink("stdout");
+// /* handle the error */
+//
+// int result = logger_attach_sink("file /some/file/path")
+// /* handle the error */
+//
+// int result = logger_apply();
+// /* handle the error */
+// ```
+
+/// Initialize the thread-local logger with no sinks.
+///
+/// This initialized logger does nothing until `logger_apply` has been called.
+#[no_mangle]
+pub extern "C" fn logger_init() {
+    set_logger(Dispatch::new());
+}
+
+/// Attach an additional sink to the thread-local logger.
+///
+/// This logger does nothing until `logger_apply` has been called.
+#[no_mangle]
+pub extern "C" fn logger_attach_sink(
+    sink_specifier: *const c_char,
+    level_filter: LevelFilter,
+) -> c_int {
+    // Get the specifier from the raw C string.
+    let sink_specifier = unsafe { CStr::from_ptr(sink_specifier) };
+    let sink_specifier = match sink_specifier.to_str() {
+        Ok(sink_specifier) => sink_specifier,
+        Err(_) => return Status::SpecifierNotUtf8 as c_int,
+    };
+
+    // Attempt to construct a sink from the specifier.
+    let sink = match Sink::try_from(sink_specifier) {
+        Ok(sink) => sink,
+        Err(err) => return Status::from(err) as c_int,
+    };
+
+    // Convert from our `#[repr(C)]` LevelFilter to the one from the `log` crate.
+    let level_filter: LogLevelFilter = level_filter.into();
+
+    // Construct a dispatcher from the sink and level filter.
+    let dispatch =
+        Into::<Dispatch>::into(sink)
+            .level(level_filter)
+            .format(|out, message, record| {
+                out.finish(format_args!(
+                    "[{}][{}] {}",
+                    record.level(),
+                    record.target(),
+                    message
+                ))
+            });
+
+    // Take the existing logger, if there is one, add a new sink to it, and put it back.
+    let status = match add_sink(dispatch) {
+        Ok(_) => Status::Success,
+        Err(err) => Status::from(err),
+    };
+
+    status as c_int
+}
+
+/// Apply the thread-local logger to the program.
+///
+/// Any attempts to modify the logger after the call to `logger_apply` will fail.
+#[no_mangle]
+pub extern "C" fn logger_apply() -> c_int {
+    let status = match apply_logger() {
+        Ok(_) => Status::Success,
+        Err(err) => Status::from(err),
+    };
+
+    status as c_int
+}

--- a/rust/pact_matching_ffi/src/log/ffi.rs
+++ b/rust/pact_matching_ffi/src/log/ffi.rs
@@ -71,17 +71,16 @@ pub extern "C" fn logger_attach_sink(
     let level_filter: LogLevelFilter = level_filter.into();
 
     // Construct a dispatcher from the sink and level filter.
-    let dispatch =
-        Into::<Dispatch>::into(sink)
-            .level(level_filter)
-            .format(|out, message, record| {
-                out.finish(format_args!(
-                    "[{}][{}] {}",
-                    record.level(),
-                    record.target(),
-                    message
-                ))
-            });
+    let dispatch = Into::<Dispatch>::into(sink)
+        .level(level_filter)
+        .format(|out, message, record| {
+            out.finish(format_args!(
+                "[{}][{}] {}",
+                record.level(),
+                record.target(),
+                message
+            ))
+        });
 
     // Take the existing logger, if there is one, add a new sink to it, and put it back.
     let status = match add_sink(dispatch) {

--- a/rust/pact_matching_ffi/src/log/level_filter.rs
+++ b/rust/pact_matching_ffi/src/log/level_filter.rs
@@ -1,0 +1,45 @@
+//! The FFI-friendly level filter to be applied on a per-sink basis.
+
+use log::LevelFilter as NonCLevelFilter;
+
+/// An enum representing the log level to use.
+///
+/// This is exactly equivalent to `LevelFilter` from the `log` crate,
+/// except that it's `#[repr(C)]`, meaning it's safe to put in the signature
+/// of a C-exposed FFI function.
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub enum LevelFilter {
+    Off,
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+impl From<NonCLevelFilter> for LevelFilter {
+    fn from(filter: NonCLevelFilter) -> LevelFilter {
+        match filter {
+            NonCLevelFilter::Off => LevelFilter::Off,
+            NonCLevelFilter::Error => LevelFilter::Error,
+            NonCLevelFilter::Warn => LevelFilter::Warn,
+            NonCLevelFilter::Info => LevelFilter::Info,
+            NonCLevelFilter::Debug => LevelFilter::Debug,
+            NonCLevelFilter::Trace => LevelFilter::Trace,
+        }
+    }
+}
+
+impl Into<NonCLevelFilter> for LevelFilter {
+    fn into(self) -> NonCLevelFilter {
+        match self {
+            LevelFilter::Off => NonCLevelFilter::Off,
+            LevelFilter::Error => NonCLevelFilter::Error,
+            LevelFilter::Warn => NonCLevelFilter::Warn,
+            LevelFilter::Info => NonCLevelFilter::Info,
+            LevelFilter::Debug => NonCLevelFilter::Debug,
+            LevelFilter::Trace => NonCLevelFilter::Trace,
+        }
+    }
+}

--- a/rust/pact_matching_ffi/src/log/logger.rs
+++ b/rust/pact_matching_ffi/src/log/logger.rs
@@ -1,0 +1,49 @@
+//! The thread-local log dispatcher, which is cleared once applied.
+
+use fern::Dispatch;
+use log::SetLoggerError;
+use std::cell::RefCell;
+
+thread_local! {
+    /// The thread-local logger. This is only populated during setup of the logger.
+    pub(crate) static LOGGER: RefCell<Option<Dispatch>> = RefCell::new(None);
+}
+
+/// Set a new dispatcher as the logger-in-progress.
+pub(crate) fn set_logger(dispatch: Dispatch) {
+    LOGGER.with(|logger| {
+        *logger.borrow_mut() = Some(dispatch);
+    });
+}
+
+/// Attach a sink to the logger-in-progress.
+pub(crate) fn add_sink(dispatch: Dispatch) -> Result<(), LoggerError> {
+    match LOGGER.with(|logger| logger.borrow_mut().take()) {
+        None => Err(LoggerError::NoLogger),
+        Some(top_level_dispatch) => {
+            let top_level_dispatch = top_level_dispatch.chain(dispatch);
+
+            LOGGER.with(|logger| *logger.borrow_mut() = Some(top_level_dispatch));
+
+            Ok(())
+        }
+    }
+}
+
+/// Apply the logger-in-progress as the global logger.
+pub(crate) fn apply_logger() -> Result<(), LoggerError> {
+    match LOGGER.with(|logger| logger.borrow_mut().take()) {
+        Some(logger) => Ok(logger.apply()?),
+        None => Err(LoggerError::NoLogger),
+    }
+}
+
+/// An error arising from initializing, populating, and applying the logger.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum LoggerError {
+    #[error("no logger initialized")]
+    NoLogger,
+
+    #[error(transparent)]
+    ApplyLoggerFailed(#[from] SetLoggerError),
+}

--- a/rust/pact_matching_ffi/src/log/logger.rs
+++ b/rust/pact_matching_ffi/src/log/logger.rs
@@ -23,7 +23,9 @@ pub(crate) fn add_sink(dispatch: Dispatch) -> Result<(), LoggerError> {
         Some(top_level_dispatch) => {
             let top_level_dispatch = top_level_dispatch.chain(dispatch);
 
-            LOGGER.with(|logger| *logger.borrow_mut() = Some(top_level_dispatch));
+            LOGGER.with(|logger| {
+                *logger.borrow_mut() = Some(top_level_dispatch)
+            });
 
             Ok(())
         }

--- a/rust/pact_matching_ffi/src/log/mod.rs
+++ b/rust/pact_matching_ffi/src/log/mod.rs
@@ -9,5 +9,7 @@ mod sink;
 mod status;
 mod target;
 
-pub use crate::log::ffi::{logger_apply, logger_attach_sink, logger_init};
+pub use crate::log::ffi::{
+    logger_apply, logger_attach_sink, logger_init,
+};
 pub(crate) use crate::log::target::TARGET;

--- a/rust/pact_matching_ffi/src/log/mod.rs
+++ b/rust/pact_matching_ffi/src/log/mod.rs
@@ -1,0 +1,13 @@
+//! Sets up a log sink to view logs from the FFI.
+
+#![allow(unused)]
+
+mod ffi;
+mod level_filter;
+mod logger;
+mod sink;
+mod status;
+mod target;
+
+pub use crate::log::ffi::{logger_apply, logger_attach_sink, logger_init};
+pub(crate) use crate::log::target::TARGET;

--- a/rust/pact_matching_ffi/src/log/sink.rs
+++ b/rust/pact_matching_ffi/src/log/sink.rs
@@ -1,0 +1,86 @@
+//! The sinks to which logs may be sent.
+
+use fern::Dispatch;
+use std::convert::TryFrom;
+use std::fs::File;
+use std::io::{self, Stderr, Stdout};
+use std::ops::Not;
+use std::path::PathBuf;
+use std::str::FromStr;
+
+/// A sink for logs to be written to, based on a provider specifier.
+#[derive(Debug)]
+pub(crate) enum Sink {
+    /// Write logs to stdout.
+    Stdout(Stdout),
+
+    /// Write logs to stderr.
+    Stderr(Stderr),
+
+    /// Write logs to a file.
+    File(File),
+}
+
+impl Into<Dispatch> for Sink {
+    fn into(self) -> Dispatch {
+        let dispatch = Dispatch::new();
+
+        match self {
+            Sink::Stdout(stdout) => dispatch.chain(stdout),
+            Sink::Stderr(stderr) => dispatch.chain(stderr),
+            Sink::File(file) => dispatch.chain(file),
+        }
+    }
+}
+
+impl<'a> TryFrom<&'a str> for Sink {
+    type Error = SinkSpecifierError;
+
+    fn try_from(s: &'a str) -> Result<Sink, Self::Error> {
+        let s = s.trim();
+
+        if s == "stdout" {
+            return Ok(Sink::Stdout(io::stdout()));
+        } else if s == "stderr" {
+            return Ok(Sink::Stderr(io::stderr()));
+        }
+
+        let pat = "file ";
+
+        if s.starts_with(pat).not() {
+            return Err(SinkSpecifierError::UnknownSinkType { name: s.to_owned() });
+        }
+
+        match s.get(pat.len()..) {
+            None => return Err(SinkSpecifierError::MissingFilePath),
+            Some(remainder) => {
+                match File::create(remainder) {
+                    Ok(file) => Ok(Sink::File(file)),
+                    Err(source) => {
+                        // PANIC SAFETY: This `unwrap` is fine because the `PathBuf` impl of `FromStr` has an associated
+                        // `Self::Error` type of `Infallible`, indicating the operation always succeeds.
+                        let path = PathBuf::from_str(remainder).unwrap();
+                        Err(SinkSpecifierError::CantMakeFile { path, source })
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// An error arising from attempting to parse a sink specifier string.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum SinkSpecifierError {
+    #[error("unknown logger sink type (was '{name}', should be \"stdout\"/\"stderr\"/or \"file <file path>\")")]
+    UnknownSinkType { name: String },
+
+    #[error("missing path in file sink specifier")]
+    MissingFilePath,
+
+    #[error("can't make log sink file at path: '{path}'")]
+    CantMakeFile {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+}

--- a/rust/pact_matching_ffi/src/log/sink.rs
+++ b/rust/pact_matching_ffi/src/log/sink.rs
@@ -48,7 +48,9 @@ impl<'a> TryFrom<&'a str> for Sink {
         let pat = "file ";
 
         if s.starts_with(pat).not() {
-            return Err(SinkSpecifierError::UnknownSinkType { name: s.to_owned() });
+            return Err(SinkSpecifierError::UnknownSinkType {
+                name: s.to_owned(),
+            });
         }
 
         match s.get(pat.len()..) {
@@ -60,7 +62,10 @@ impl<'a> TryFrom<&'a str> for Sink {
                         // PANIC SAFETY: This `unwrap` is fine because the `PathBuf` impl of `FromStr` has an associated
                         // `Self::Error` type of `Infallible`, indicating the operation always succeeds.
                         let path = PathBuf::from_str(remainder).unwrap();
-                        Err(SinkSpecifierError::CantMakeFile { path, source })
+                        Err(SinkSpecifierError::CantMakeFile {
+                            path,
+                            source,
+                        })
                     }
                 }
             }

--- a/rust/pact_matching_ffi/src/log/status.rs
+++ b/rust/pact_matching_ffi/src/log/status.rs
@@ -37,9 +37,15 @@ impl From<SetLoggerError> for Status {
 impl From<SinkSpecifierError> for Status {
     fn from(err: SinkSpecifierError) -> Status {
         match err {
-            SinkSpecifierError::UnknownSinkType { .. } => Status::UnknownSinkType,
-            SinkSpecifierError::MissingFilePath { .. } => Status::MissingFilePath,
-            SinkSpecifierError::CantMakeFile { .. } => Status::CantOpenSinkToFile,
+            SinkSpecifierError::UnknownSinkType { .. } => {
+                Status::UnknownSinkType
+            }
+            SinkSpecifierError::MissingFilePath { .. } => {
+                Status::MissingFilePath
+            }
+            SinkSpecifierError::CantMakeFile { .. } => {
+                Status::CantOpenSinkToFile
+            }
         }
     }
 }

--- a/rust/pact_matching_ffi/src/log/status.rs
+++ b/rust/pact_matching_ffi/src/log/status.rs
@@ -1,0 +1,54 @@
+//! Status returned to the C caller for log FFI functions.
+
+use crate::log::logger::LoggerError;
+use crate::log::sink::SinkSpecifierError;
+use log::SetLoggerError;
+
+/// An enum representing the status codes which can be returned to the C caller.
+pub(crate) enum Status {
+    /// Opening a sink to the given file failed.
+    CantOpenSinkToFile = -6,
+
+    /// No file path was specified in the sink specification.
+    MissingFilePath = -5,
+
+    /// The sink type specified is not a known type.
+    UnknownSinkType = -4,
+
+    /// The sink specifier was not UTF-8 encoded.
+    SpecifierNotUtf8 = -3,
+
+    /// No logger has been initialized.
+    NoLogger = -2,
+
+    /// Can't set the logger
+    CantSetLogger = -1,
+
+    /// Operation succeeded.
+    Success = 0,
+}
+
+impl From<SetLoggerError> for Status {
+    fn from(_err: SetLoggerError) -> Status {
+        Status::CantSetLogger
+    }
+}
+
+impl From<SinkSpecifierError> for Status {
+    fn from(err: SinkSpecifierError) -> Status {
+        match err {
+            SinkSpecifierError::UnknownSinkType { .. } => Status::UnknownSinkType,
+            SinkSpecifierError::MissingFilePath { .. } => Status::MissingFilePath,
+            SinkSpecifierError::CantMakeFile { .. } => Status::CantOpenSinkToFile,
+        }
+    }
+}
+
+impl From<LoggerError> for Status {
+    fn from(err: LoggerError) -> Status {
+        match err {
+            LoggerError::NoLogger => Status::NoLogger,
+            LoggerError::ApplyLoggerFailed(err) => err.into(),
+        }
+    }
+}

--- a/rust/pact_matching_ffi/src/log/target.rs
+++ b/rust/pact_matching_ffi/src/log/target.rs
@@ -1,0 +1,9 @@
+//! The special log target to use for logs from this crate.
+
+#![allow(unused)]
+
+/// The log target to use through the crate. Note that normally the logging macros would
+/// pull the module path of the code calling the logger, but in this case everything ends up
+/// in a flat namespace on the C side anyway, and the logging makes clear what's being called.
+/// So having a singular log target is fine.
+pub(crate) const TARGET: &str = "pact::matching::ffi";

--- a/rust/pact_matching_ffi/src/util/ffi.rs
+++ b/rust/pact_matching_ffi/src/util/ffi.rs
@@ -7,8 +7,34 @@
 /// This convenience macro is intended to make it easier to write _correct_ FFI code
 /// which catches panics before they cross the language boundary, and reports its error
 /// out for the C caller to read if they want.
+#[doc(hidden)]
 macro_rules! ffi {
     ( op: $op:block, fail: $fail:block ) => {{
-        $crate::error::catch_panic(|| $op).unwrap_or($fail)
+        compile_error!("the ffi macro must include a name");
+    }};
+
+    ( name: $name:literal, op: $op:block, fail: $fail:block ) => {{
+        ffi! {
+            name: $name,
+            params: [],
+            op: $op,
+            fail: $fail
+        }
+    }};
+
+    ( name: $name:literal, params: [ $( $params:ident ),* ], op: $op:block, fail: $fail:block ) => {{
+        use $crate::log::TARGET;
+
+        log::debug!(target: TARGET, "{}::{}", module_path!(), $name);
+
+        $(
+            log::trace!(target: TARGET, "@param $params = {:?}", $params);
+        ),*
+
+        let output = $crate::error::catch_panic(|| $op).unwrap_or($fail);
+
+        log::trace!(target: TARGET, "@return {:?}", output);
+
+        output
     }};
 }

--- a/rust/pact_matching_ffi/src/util/write.rs
+++ b/rust/pact_matching_ffi/src/util/write.rs
@@ -8,7 +8,10 @@ use zeroize::Zeroize;
 ///
 /// This performs a write, including the null terminator and performing zeroization of any
 /// excess in the destination buffer.
-pub(crate) fn write_to_c_buf(src: &str, dst: &mut [u8]) -> Result<(), WriteBufError> {
+pub(crate) fn write_to_c_buf(
+    src: &str,
+    dst: &mut [u8],
+) -> Result<(), WriteBufError> {
     // Ensure the string has the null terminator.
     let src = CString::new(src.as_bytes())?;
     let src = src.as_bytes_with_nul();


### PR DESCRIPTION
Added mechanism for C callers to configure log sinks and set up the
logger, and for the FFI code to log function names, parameter values,
and return values.

Closes #3 