### PR TITLE
Bump pact_matching version in FFI

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -504,12 +504,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fixedbitset"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
-
-[[package]]
 name = "fern"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -517,6 +511,12 @@ checksum = "8c9a4820f0ccc8a7afd67c39a0f1a0f4b07ca1725164271a64939d7aeb9af065"
 dependencies = [
  "log 0.4.8",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "fnv"
@@ -2588,9 +2588,9 @@ version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca972988113b7715266f91250ddb98070d033c62a011fa0fcc57434a649310dd"
 dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.3",
- "syn 1.0.17",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.33",
 ]
 
 [[package]]

--- a/rust/pact_matching_ffi/Cargo.toml
+++ b/rust/pact_matching_ffi/Cargo.toml
@@ -12,7 +12,7 @@ exclude = [
 ]
 
 [dependencies]
-pact_matching = { version = "0.5.11", path = "../pact_matching" }
+pact_matching = { version = "0.6.4", path = "../pact_matching" }
 anyhow = "1.0.28"
 libc = "0.2.69"
 zeroize = "1.1.0"

--- a/rust/pact_matching_ffi/src/error/ffi.rs
+++ b/rust/pact_matching_ffi/src/error/ffi.rs
@@ -40,7 +40,7 @@ pub extern "C" fn get_error_message(
     };
 
     // Get the last error, possibly empty if there isn't one.
-    let last_err = get_error_msg().unwrap_or(String::new());
+    let last_err = get_error_msg().unwrap_or_else(String::new);
 
     // Try to write the error to the buffer.
     let status = match write_to_c_buf(&last_err, buffer) {

--- a/rust/pact_matching_ffi/src/log/ffi.rs
+++ b/rust/pact_matching_ffi/src/log/ffi.rs
@@ -49,13 +49,14 @@ pub extern "C" fn logger_init() {
 /// Attach an additional sink to the thread-local logger.
 ///
 /// This logger does nothing until `logger_apply` has been called.
+#[allow(clippy::missing_safety_doc)]
 #[no_mangle]
 pub extern "C" fn logger_attach_sink(
     sink_specifier: *const c_char,
     level_filter: LevelFilter,
 ) -> c_int {
     // Get the specifier from the raw C string.
-    let sink_specifier = unsafe { CStr::from_ptr(sink_specifier) };
+    let sink_specifier = CStr::from_ptr(sink_specifier);
     let sink_specifier = match sink_specifier.to_str() {
         Ok(sink_specifier) => sink_specifier,
         Err(_) => return Status::SpecifierNotUtf8 as c_int,

--- a/rust/pact_matching_ffi/src/log/ffi.rs
+++ b/rust/pact_matching_ffi/src/log/ffi.rs
@@ -51,7 +51,7 @@ pub extern "C" fn logger_init() {
 /// This logger does nothing until `logger_apply` has been called.
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
-pub extern "C" fn logger_attach_sink(
+pub unsafe extern "C" fn logger_attach_sink(
     sink_specifier: *const c_char,
     level_filter: LevelFilter,
 ) -> c_int {

--- a/rust/pact_matching_ffi/src/log/ffi.rs
+++ b/rust/pact_matching_ffi/src/log/ffi.rs
@@ -56,7 +56,7 @@ pub extern "C" fn logger_attach_sink(
     level_filter: LevelFilter,
 ) -> c_int {
     // Get the specifier from the raw C string.
-    let sink_specifier = CStr::from_ptr(sink_specifier);
+    let sink_specifier = unsafe { CStr::from_ptr(sink_specifier) };
     let sink_specifier = match sink_specifier.to_str() {
         Ok(sink_specifier) => sink_specifier,
         Err(_) => return Status::SpecifierNotUtf8 as c_int,

--- a/rust/pact_matching_ffi/src/log/sink.rs
+++ b/rust/pact_matching_ffi/src/log/sink.rs
@@ -54,7 +54,7 @@ impl<'a> TryFrom<&'a str> for Sink {
         }
 
         match s.get(pat.len()..) {
-            None => return Err(SinkSpecifierError::MissingFilePath),
+            None => Err(SinkSpecifierError::MissingFilePath),
             Some(remainder) => {
                 match File::create(remainder) {
                     Ok(file) => Ok(Sink::File(file)),

--- a/rust/pact_matching_ffi/src/util/write.rs
+++ b/rust/pact_matching_ffi/src/util/write.rs
@@ -63,7 +63,7 @@ trait ZeroizedWrite: Write {
 }
 
 impl<'a> ZeroizedWrite for &'a mut [u8] {
-    fn zeroized_write<'b>(mut self, buf: &'b [u8]) -> io::Result<()> {
+    fn zeroized_write(mut self, buf: &[u8]) -> io::Result<()> {
         // Write the buffer.
         self.write_all(buf)?;
 


### PR DESCRIPTION
Fixes breakage from the rebase on top of the latest from upstream master, bumping the `pact_matching` dependency in `pact_matching_ffi` to the latest `pact_matching` version.