### PR TITLE
Configured CMake to run Doxygen on FFI header file

### DIFF
--- a/rust/pact_matching_ffi/CMakeLists.txt
+++ b/rust/pact_matching_ffi/CMakeLists.txt
@@ -149,6 +149,9 @@ find_package(Cargo REQUIRED)
 # Uses the finder specified in `cmake/FindCbindgen.cmake`
 find_package(Cbindgen REQUIRED)
 
+# CMake can find Doxygen without a custom finder module.
+find_package(Doxygen)
+
 #################################################################################################
 # VARIABLES
 #
@@ -249,6 +252,24 @@ add_custom_target(generate_header ALL
 
 # Teach CMake to install the header file built by the generate_header target
 install(FILES "${CBINDGEN_HEADER_FILE}" TYPE INCLUDE)
+
+
+#################################################################################################
+# DOXYGEN
+#
+# Generates configuration for Doxygen and runs it to generate documentation.
+#################################################################################################
+
+if(DOXYGEN_FOUND)
+    doxygen_add_docs(
+        generate_docs
+        ${CBINDGEN_HEADER_FILE}
+        ALL
+        USE_STAMP_FILE
+        COMMENT "Generating documentation with doxygen")
+else()
+    message(WARNING "Could not find Doxygen; FFI documentation will not be generated")
+endif()
 
 #################################################################################################
 # PACKAGE FILES

--- a/rust/pact_matching_ffi/cbindgen.toml
+++ b/rust/pact_matching_ffi/cbindgen.toml
@@ -26,7 +26,7 @@ cpp_compat = true
 braces = "SameLine"
 line_length = 100
 tab_width = 2
-documentation_style = "auto"
+documentation_style = "doxy"
 
 ############################# Codegen Options ##################################
 


### PR DESCRIPTION
Updated the CMake configuration to find and run Doxygen to generate docs for the FFI header, or to print a warning to the user if Doxygen isn't found, and updated the cbindgen config to more explicitly generate Doxygen-style comments in the header file.