### PR TITLE
Added metadata key/value iteration

### DIFF
--- a/rust/pact_matching_ffi/src/models/message.rs
+++ b/rust/pact_matching_ffi/src/models/message.rs
@@ -275,13 +275,14 @@ pub unsafe extern "C" fn message_insert_metadata(
     }
 }
 
-/// Get a copy of the metadata list from this message.
-/// It is in the form of a list of (key, value) pairs,
-/// in an unspecified order.
-/// The returned structure must be deleted with `metadata_list_delete`.
+
+/// Get an iterator over the metadata of a message.
 ///
-/// Since it is a copy, the returned structure may safely outlive
-/// the `Message`.
+/// This iterator carries a pointer to the message, and must
+/// not outlive the message.
+///
+/// The message metadata also must not be modified during iteration. If it is,
+/// the old iterator must be deleted and a new iterator created.
 ///
 /// # Errors
 ///

--- a/rust/pact_matching_ffi/src/util/ptr.rs
+++ b/rust/pact_matching_ffi/src/util/ptr.rs
@@ -36,7 +36,7 @@ pub(crate) fn null_mut_to<T>() -> *mut T {
 /// Get an immutable reference from a raw pointer
 #[macro_export]
 macro_rules! as_ref {
-    ( $name:ident ) => {{
+    ( $name:expr ) => {{
         $name
             .as_ref()
             .ok_or(anyhow!(concat!(stringify!($name), " is null")))?
@@ -46,7 +46,7 @@ macro_rules! as_ref {
 /// Get a mutable reference from a raw pointer
 #[macro_export]
 macro_rules! as_mut {
-    ( $name:ident ) => {{
+    ( $name:expr ) => {{
         $name
             .as_mut()
             .ok_or(anyhow!(concat!(stringify!($name), " is null")))?

--- a/rust/pact_matching_ffi/src/util/string.rs
+++ b/rust/pact_matching_ffi/src/util/string.rs
@@ -7,9 +7,7 @@ use std::ffi::CString;
 ///
 /// The returned pointer must be passed to CString::from_raw to
 /// prevent leaking memory.
-pub(crate) fn into_leaked_cstring(
-    t: &str,
-) -> anyhow::Result<*mut c_char> {
+pub(crate) fn to_c(t: &str) -> anyhow::Result<*mut c_char> {
     Ok(CString::new(t)?.into_raw())
 }
 

--- a/rust/pact_matching_ffi/src/util/string.rs
+++ b/rust/pact_matching_ffi/src/util/string.rs
@@ -1,6 +1,5 @@
 use libc::c_char;
 use std::ffi::CString;
-use std::mem;
 
 /// Converts the string into a C-compatible null terminated string,
 /// then forgets the container while returning a pointer to the
@@ -10,15 +9,8 @@ use std::mem;
 /// prevent leaking memory.
 pub(crate) fn into_leaked_cstring(
     t: &str,
-) -> anyhow::Result<*const c_char> {
-    let copy = CString::new(t)?;
-    let ptr = copy.as_ptr();
-
-    // Intentionally leak this memory so that it stays
-    // valid while C is using it.
-    mem::forget(copy);
-
-    Ok(ptr)
+) -> anyhow::Result<*mut c_char> {
+    Ok(CString::new(t)?.into_raw())
 }
 
 /// Delete a string previously returned by this FFI.


### PR DESCRIPTION
A couple notes:

* This exposes a `#[repr(C)]` type called `MetadataPair` that contains the key and value strings, and has an associated `metadata_pair_delete` function.
* The iterator type is opaque on the C side, and contains an owned copy of all hashes, an index for iteration, and a pointer to the `Message`. If the `Message` you're iterating over is deallocated, that pointer will be invalid.