### PR TITLE
Bump pact_matching dependency version

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -512,7 +512,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9a4820f0ccc8a7afd67c39a0f1a0f4b07ca1725164271a64939d7aeb9af065"
 dependencies = [
- "log 0.4.8",
+ "log 0.4.11",
 ]
 
 [[package]]
@@ -1514,7 +1514,7 @@ dependencies = [
  "anyhow",
  "fern",
  "libc",
- "log 0.4.8",
+ "log 0.4.11",
  "pact_matching",
  "serde_json",
  "thiserror",
@@ -2591,9 +2591,9 @@ version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca972988113b7715266f91250ddb98070d033c62a011fa0fcc57434a649310dd"
 dependencies = [
- "proc-macro2 1.0.18",
+ "proc-macro2 1.0.21",
  "quote 1.0.7",
- "syn 1.0.33",
+ "syn 1.0.41",
 ]
 
 [[package]]

--- a/rust/pact_matching_ffi/Cargo.toml
+++ b/rust/pact_matching_ffi/Cargo.toml
@@ -12,7 +12,7 @@ exclude = [
 ]
 
 [dependencies]
-pact_matching = { version = "0.6.4", path = "../pact_matching" }
+pact_matching = { version = "0.7.1", path = "../pact_matching" }
 anyhow = "1.0.28"
 libc = "0.2.69"
 zeroize = "1.1.0"


### PR DESCRIPTION
Unintentionally broke the build with my rebase, as `pact_matching_ffi`
currently locks the `pact_matching` version number, and it had changed
upstream. In the future, the Pact project may prefer to leave off the
version number, but for us it makes things more predictable.