### PR TITLE
Add FFI methods to get consumer and provider from MessagePact

### DIFF
--- a/rust/pact_matching_ffi/src/models/consumer.rs
+++ b/rust/pact_matching_ffi/src/models/consumer.rs
@@ -1,0 +1,35 @@
+//! FFI wrapper code for pact_matching::models::Consumer
+use libc::c_char;
+
+use anyhow::anyhow;
+
+pub use pact_matching::models::Consumer;
+
+use crate::util::*;
+use crate::{as_ref, ffi};
+
+/// Get a copy of this consumer's name.
+/// The copy must be deleted with `string_delete`.
+///
+/// # Errors
+///
+/// This function will fail if it is passed a NULL pointer,
+/// or the Rust string contains an embedded NULL byte.
+/// In the case of error, a NULL pointer will be returned.
+#[no_mangle]
+#[allow(clippy::missing_safety_doc)]
+pub unsafe extern "C" fn consumer_get_name(
+    consumer: *const Consumer,
+) -> *const c_char {
+    ffi! {
+        name: "consumer_get_name",
+        params: [consumer],
+        op: {
+            let consumer = as_ref!(consumer);
+            Ok(string::to_c(&consumer.name)? as *const c_char)
+        },
+        fail: {
+            ptr::null_to::<c_char>()
+        }
+    }
+}

--- a/rust/pact_matching_ffi/src/models/message_pact.rs
+++ b/rust/pact_matching_ffi/src/models/message_pact.rs
@@ -5,9 +5,11 @@ use libc::{c_char, c_int, EXIT_FAILURE, EXIT_SUCCESS};
 
 // Necessary to make 'cbindgen' generate an opaque struct on the C side.
 pub use pact_matching::models::message_pact::MessagePact;
+use pact_matching::models::Consumer;
+use pact_matching::models::Provider;
 
 use crate::util::*;
-use crate::{cstr, ffi, safe_str};
+use crate::{as_mut, cstr, ffi, safe_str};
 
 /// Construct a new `MessagePact` from the JSON string.
 /// The provided file name is used when generating error messages.
@@ -60,3 +62,56 @@ pub unsafe extern "C" fn message_pact_delete(
     }
 }
 
+/// Get a pointer to the Consumer struct inside the MessagePact.
+/// This is a mutable borrow: The caller may mutate the Consumer
+/// through this pointer.
+///
+/// # Errors
+///
+/// This function will only fail if it is passed a NULL pointer.
+/// In the case of error, a NULL pointer will be returned.
+#[no_mangle]
+#[allow(clippy::missing_safety_doc)]
+pub unsafe extern "C" fn message_pact_get_consumer(
+    message_pact: *mut MessagePact,
+) -> *mut Consumer {
+    ffi! {
+        name: "message_pact_get_consumer",
+        params: [message_pact],
+        op: {
+            let message_pact = as_mut!(message_pact);
+            let consumer = &mut message_pact.consumer;
+            Ok(consumer as *mut Consumer)
+        },
+        fail: {
+            ptr::null_mut_to::<Consumer>()
+        }
+    }
+}
+
+/// Get a pointer to the Provider struct inside the MessagePact.
+/// This is a mutable borrow: The caller may mutate the Provider
+/// through this pointer.
+///
+/// # Errors
+///
+/// This function will only fail if it is passed a NULL pointer.
+/// In the case of error, a NULL pointer will be returned.
+#[no_mangle]
+#[allow(clippy::missing_safety_doc)]
+pub unsafe extern "C" fn message_pact_get_provider(
+    message_pact: *mut MessagePact,
+) -> *mut Provider {
+    ffi! {
+        name: "message_pact_get_provider",
+        params: [message_pact],
+        op: {
+            let message_pact = as_mut!(message_pact);
+            let provider = &mut message_pact.provider;
+            Ok(provider as *mut Provider)
+        },
+        fail: {
+            ptr::null_mut_to::<Provider>()
+        }
+    }
+}

--- a/rust/pact_matching_ffi/src/models/mod.rs
+++ b/rust/pact_matching_ffi/src/models/mod.rs
@@ -1,6 +1,8 @@
 //! Represents messages in `pact_matching`.
 
+pub mod consumer;
 pub mod message;
 pub mod message_pact;
 pub mod pact_specification;
+pub mod provider;
 pub mod provider_state;

--- a/rust/pact_matching_ffi/src/models/provider.rs
+++ b/rust/pact_matching_ffi/src/models/provider.rs
@@ -1,0 +1,35 @@
+//! FFI wrapper code for pact_matching::models::Provider
+use libc::c_char;
+
+use anyhow::anyhow;
+
+pub use pact_matching::models::Provider;
+
+use crate::util::*;
+use crate::{as_ref, ffi};
+
+/// Get a copy of this provider's name.
+/// The copy must be deleted with `string_delete`.
+///
+/// # Errors
+///
+/// This function will fail if it is passed a NULL pointer,
+/// or the Rust string contains an embedded NULL byte.
+/// In the case of error, a NULL pointer will be returned.
+#[no_mangle]
+#[allow(clippy::missing_safety_doc)]
+pub unsafe extern "C" fn provider_get_name(
+    provider: *const Provider,
+) -> *const c_char {
+    ffi! {
+        name: "provider_get_name",
+        params: [provider],
+        op: {
+            let provider = as_ref!(provider);
+            Ok(string::to_c(&provider.name)? as *const c_char)
+        },
+        fail: {
+            ptr::null_to::<c_char>()
+        }
+    }
+}


### PR DESCRIPTION
Also add methods to read the names contained in Consumer and Provider.

Fixes #39, Fixes #40