### PR TITLE
Resolve some warnings during CMake build.

### DIFF
--- a/rust/pact_matching_ffi/src/error/last_error.rs
+++ b/rust/pact_matching_ffi/src/error/last_error.rs
@@ -3,7 +3,8 @@
 use std::cell::RefCell;
 
 thread_local! {
-    /// The last error to have been reported by the FFI code.
+    // The last error to have been reported by the FFI code.
+    /// cbindgen:ignore
     static LAST_ERROR: RefCell<Option<String>> = RefCell::new(None);
 }
 

--- a/rust/pact_matching_ffi/src/log/logger.rs
+++ b/rust/pact_matching_ffi/src/log/logger.rs
@@ -5,7 +5,8 @@ use log::SetLoggerError;
 use std::cell::RefCell;
 
 thread_local! {
-    /// The thread-local logger. This is only populated during setup of the logger.
+    // The thread-local logger. This is only populated during setup of the logger.
+    /// cbindgen:ignore
     pub(crate) static LOGGER: RefCell<Option<Dispatch>> = RefCell::new(None);
 }
 

--- a/rust/pact_matching_ffi/src/models/message.rs
+++ b/rust/pact_matching_ffi/src/models/message.rs
@@ -382,7 +382,9 @@ impl MessageMetadataIterator {
 #[repr(C)]
 #[allow(missing_copy_implementations)]
 pub struct MessageMetadataPair {
+    /// The metadata key.
     key: *const c_char,
+    /// The metadata value.
     value: *const c_char,
 }
 

--- a/rust/pact_matching_ffi/src/models/message_pact.rs
+++ b/rust/pact_matching_ffi/src/models/message_pact.rs
@@ -217,8 +217,11 @@ impl MessagePactMetadataIterator {
 #[repr(C)]
 #[allow(missing_copy_implementations)]
 pub struct MessagePactMetadataTriple {
+    /// The outer key of the `MessagePact` metadata.
     outer_key: *const c_char,
+    /// The inner key of the `MessagePact` metadata.
     inner_key: *const c_char,
+    /// The value of the `MessagePact` metadata.
     value: *const c_char,
 }
 

--- a/rust/pact_matching_ffi/src/models/provider_state.rs
+++ b/rust/pact_matching_ffi/src/models/provider_state.rs
@@ -115,7 +115,9 @@ impl ProviderStateParamIterator {
 #[repr(C)]
 #[allow(missing_copy_implementations)]
 pub struct ProviderStateParamPair {
+    /// The key of the `ProviderState` parameter.
     key: *const c_char,
+    /// The value of the `ProviderState` parameter.
     value: *const c_char,
 }
 


### PR DESCRIPTION
Right now, we get some warnings from the CMake-driven build about not generating docs for two items marked `pub(crate)` (`cbindgen`), and missing documentation for some struct fields (Doxygen). This PR resolves those warnings.