### PR TITLE
Use absolute paths in macros for hygiene

### DIFF
--- a/rust/pact_matching_ffi/src/models/message.rs
+++ b/rust/pact_matching_ffi/src/models/message.rs
@@ -6,7 +6,7 @@
 
 use crate::models::pact_specification::PactSpecification;
 use crate::util::*;
-use crate::{as_mut, as_ref, cstr, ffi_fn, safe_str};
+use crate::{as_mut, as_ref, ffi_fn, safe_str};
 use anyhow::{anyhow, Context};
 use libc::{c_char, c_int, c_uint, EXIT_FAILURE, EXIT_SUCCESS};
 use pact_matching::models::OptionalBody;

--- a/rust/pact_matching_ffi/src/models/message_pact.rs
+++ b/rust/pact_matching_ffi/src/models/message_pact.rs
@@ -1,7 +1,7 @@
 //! FFI wrapper for `MessagePact` from pact_matching.
 
 use crate::util::*;
-use crate::{as_mut, as_ref, cstr, ffi_fn, safe_str};
+use crate::{as_mut, as_ref, ffi_fn, safe_str};
 use anyhow::{anyhow, Context};
 use libc::c_char;
 use std::iter::{self, Iterator};

--- a/rust/pact_matching_ffi/src/util/ffi.rs
+++ b/rust/pact_matching_ffi/src/util/ffi.rs
@@ -26,6 +26,6 @@ macro_rules! ffi_fn {
     };
 
     ($(#[$doc:meta])* fn $name:ident($($arg:ident: $arg_ty:ty),*) $body:block ) => {
-        ffi_fn!($(#[$doc])* fn $name($($arg: $arg_ty),*) -> () $body {});
+        $crate::ffi_fn!($(#[$doc])* fn $name($($arg: $arg_ty),*) -> () $body {});
     };
 }

--- a/rust/pact_matching_ffi/src/util/ptr.rs
+++ b/rust/pact_matching_ffi/src/util/ptr.rs
@@ -37,7 +37,7 @@ pub(crate) fn null_mut_to<T>() -> *mut T {
 #[macro_export]
 macro_rules! as_ref {
     ( $name:expr ) => {{
-        unsafe { $name.as_ref() }.ok_or(anyhow::anyhow!(concat!(
+        unsafe { $name.as_ref() }.ok_or(::anyhow::anyhow!(concat!(
             stringify!($name),
             " is null"
         )))?
@@ -48,7 +48,7 @@ macro_rules! as_ref {
 #[macro_export]
 macro_rules! as_mut {
     ( $name:expr ) => {{
-        unsafe { $name.as_mut() }.ok_or(anyhow::anyhow!(concat!(
+        unsafe { $name.as_mut() }.ok_or(::anyhow::anyhow!(concat!(
             stringify!($name),
             " is null"
         )))?

--- a/rust/pact_matching_ffi/src/util/string.rs
+++ b/rust/pact_matching_ffi/src/util/string.rs
@@ -30,10 +30,10 @@ ffi_fn! {
 #[macro_export]
 macro_rules! cstr {
     ( $name:ident ) => {{
-        use std::ffi::CStr;
+        use ::std::ffi::CStr;
 
         if $name.is_null() {
-            anyhow::bail!(concat!(stringify!($name), " is null"));
+            ::anyhow::bail!(concat!(stringify!($name), " is null"));
         }
 
         unsafe { CStr::from_ptr($name) }
@@ -44,7 +44,7 @@ macro_rules! cstr {
 #[macro_export]
 macro_rules! safe_str {
     ( $name:ident ) => {{
-        cstr!($name).to_str().context(concat!(
+        $crate::cstr!($name).to_str().context(concat!(
             "error parsing ",
             stringify!($name),
             " as UTF-8"


### PR DESCRIPTION
This allows client code to avoid importing the helper macro `cstr` if only `safe_str` is used.

The absolute paths should also protect against namespace collisions.