### PR TITLE
refactor: Move path functions, and make JSON parsing fallible

### DIFF
--- a/rust/pact_matching/src/lib.rs
+++ b/rust/pact_matching/src/lib.rs
@@ -355,7 +355,8 @@ use pact_models::generators::{apply_generators, GenerateValue, GeneratorCategory
 use pact_models::http_parts::HttpPart;
 use pact_models::interaction::Interaction;
 use pact_models::json_utils::json_to_string;
-use pact_models::matchingrules::{calc_path_weight, Category, MatchingRule, MatchingRuleCategory, path_length, RuleList};
+use pact_models::matchingrules::{Category, MatchingRule, MatchingRuleCategory, RuleList};
+use pact_models::path_exp::{calc_path_weight, path_length};
 use pact_models::PactSpecification;
 use pact_models::request::Request;
 use pact_models::response::Response;

--- a/rust/pact_models/src/generators.rs
+++ b/rust/pact_models/src/generators.rs
@@ -629,7 +629,8 @@ impl Generators {
   }
 
   /// Loads the generators for a JSON map
-  pub fn load_from_map(&mut self, map: &serde_json::Map<String, Value>) {
+  pub fn load_from_map(&mut self, map: &serde_json::Map<String, Value>
+  ) -> anyhow::Result<()> {
     for (k, v) in map {
       match v {
         &Value::Object(ref map) =>  match GeneratorCategory::from_str(k) {
@@ -649,6 +650,7 @@ impl Generators {
         _ => log::warn!("Ignoring invalid generator JSON '{}' -> {:?}", k, v)
       }
     }
+    Ok(())
   }
 
   pub(crate) fn parse_generator_from_map(&mut self, category: &GeneratorCategory,
@@ -755,19 +757,19 @@ pub fn apply_generators<F>(
 }
 
 /// Parses the generators from the Value structure
-pub fn generators_from_json(value: &Value) -> Generators {
+pub fn generators_from_json(value: &Value) -> anyhow::Result<Generators> {
   let mut generators = Generators::default();
   match value {
     &Value::Object(ref m) => match m.get("generators") {
       Some(gen_val) => match gen_val {
-        &Value::Object(ref m) => generators.load_from_map(m),
+        &Value::Object(ref m) => generators.load_from_map(m)?,
         _ => ()
       },
       None => ()
     },
     _ => ()
   }
-  generators
+  Ok(generators)
 }
 
 /// Generates a Value structure for the provided generators
@@ -1298,7 +1300,8 @@ mod tests {
 
   #[test]
   fn matchers_from_json_test() {
-    expect!(generators_from_json(&Value::Null).categories.iter()).to(be_empty());
+    let generators = generators_from_json(&Value::Null);
+    expect!(generators.unwrap().categories.iter()).to(be_empty());
   }
 
   #[test]

--- a/rust/pact_models/src/interaction.rs
+++ b/rust/pact_models/src/interaction.rs
@@ -147,7 +147,7 @@ pub fn http_interaction_from_json(source: &str, json: &Value, spec: &PactSpecifi
   match spec {
     PactSpecification::V4 => interaction_from_json(source, 0, json)
       .map(|i| i.boxed()),
-    _ => Ok(Box::new(RequestResponseInteraction::from_json(0, json, spec)))
+    _ => Ok(Box::new(RequestResponseInteraction::from_json(0, json, spec)?))
   }
 }
 
@@ -160,14 +160,14 @@ pub fn message_interaction_from_json(source: &str, json: &Value, spec: &PactSpec
   }
 }
 
-pub(crate) fn parse_interactions(pact_json: &Value, spec_version: PactSpecification) -> Vec<RequestResponseInteraction> {
-  match pact_json.get("interactions") {
-    Some(v) => match *v {
-      Value::Array(ref array) => array.iter().enumerate().map(|(index, ijson)| {
-        RequestResponseInteraction::from_json(index, ijson, &spec_version)
-      }).collect(),
-      _ => vec![]
-    },
-    None => vec![]
+pub(crate) fn parse_interactions(pact_json: &Value, spec_version: PactSpecification
+) -> anyhow::Result<Vec<RequestResponseInteraction>> {
+  if let Some(&Value::Array(ref array)) = pact_json.get("interactions") {
+    array.iter().enumerate().map(|(index, ijson)| {
+      RequestResponseInteraction::from_json(index, ijson, &spec_version)
+    }).collect()
+  }
+  else {
+    Ok(vec![])
   }
 }

--- a/rust/pact_models/src/matchingrules.rs
+++ b/rust/pact_models/src/matchingrules.rs
@@ -17,7 +17,7 @@ use serde_json::{json, Value};
 use crate::{HttpStatus, PactSpecification};
 use crate::generators::{Generator, GeneratorCategory, Generators};
 use crate::json_utils::{json_to_num, json_to_string};
-use crate::path_exp::{parse_path_exp, PathToken};
+use crate::path_exp::{calc_path_weight, path_length};
 
 /// Set of all matching rules
 #[derive(Serialize, Deserialize, Debug, Clone, Eq)]
@@ -520,60 +520,6 @@ fn hash_and_partial_eq_for_matching_rule() {
   expect!(&ac7).to_not(be_equal_to(&ac6));
   expect!(&ac7).to_not(be_equal_to(&ac1));
 }
-
-fn matches_token(path_fragment: &str, path_token: &PathToken) -> usize {
-  match path_token {
-    PathToken::Root if path_fragment == "$" => 2,
-    PathToken::Field(name) if path_fragment == name => 2,
-    PathToken::Index(index) => match path_fragment.parse::<usize>() {
-      Ok(i) if *index == i => 2,
-      _ => 0
-    },
-    PathToken::StarIndex => match path_fragment.parse::<usize>() {
-      Ok(_) => 1,
-      _ => 0
-    },
-    PathToken::Star => 1,
-    _ => 0
-  }
-}
-
-/// Calculates the path weight for a path expression and a given path. Returns a tuple of the
-/// calculated weight and the number of path tokens matched
-pub fn calc_path_weight(path_exp: &str, path: &[&str]) -> (usize, usize) {
-  let weight = match parse_path_exp(path_exp) {
-    Ok(path_tokens) => {
-      trace!("Calculating weight for path tokens '{:?}' and path '{:?}'", path_tokens, path);
-      if path.len() >= path_tokens.len() {
-        (
-          path_tokens.iter().zip(path.iter())
-            .fold(1, |acc, (token, fragment)| acc * matches_token(fragment, token)),
-          path_tokens.len()
-        )
-      } else {
-        (0, path_tokens.len())
-      }
-    },
-    Err(err) => {
-      warn!("Failed to parse path expression - {}", err);
-      (0, 0)
-    }
-  };
-  trace!("Calculated weight {:?} for path '{}' and '{:?}'", weight, path_exp, path);
-  weight
-}
-
-/// Parses the path expression and returns the number of tokens in the path
-pub fn path_length(path_exp: &str) -> usize {
-  match parse_path_exp(path_exp) {
-    Ok(path_tokens) => path_tokens.len(),
-    Err(err) => {
-      warn!("Failed to parse path expression - {}", err);
-      0
-    }
-  }
-}
-
 
 /// Enumeration to define how to combine rules
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Eq, Hash, PartialOrd, Ord)]
@@ -1777,81 +1723,6 @@ mod tests {
             }
         };
     expect!(matchers.wildcard_matcher_is_defined("body", &vec!["$", "a", "b", "c"])).to(be_false());
-  }
-
-  #[test]
-  fn matches_token_test_with_root() {
-    expect!(matches_token("$", &PathToken::Root)).to(be_equal_to(2));
-    expect!(matches_token("path", &PathToken::Root)).to(be_equal_to(0));
-    expect!(matches_token("*", &PathToken::Root)).to(be_equal_to(0));
-  }
-
-  #[test]
-  fn matches_token_test_with_field() {
-    expect!(matches_token("$", &PathToken::Field("path".to_string()))).to(be_equal_to(0));
-    expect!(matches_token("path", &PathToken::Field("path".to_string()))).to(be_equal_to(2));
-  }
-
-  #[test]
-  fn matches_token_test_with_index() {
-    expect!(matches_token("$", &PathToken::Index(2))).to(be_equal_to(0));
-    expect!(matches_token("path", &PathToken::Index(2))).to(be_equal_to(0));
-    expect!(matches_token("*", &PathToken::Index(2))).to(be_equal_to(0));
-    expect!(matches_token("1", &PathToken::Index(2))).to(be_equal_to(0));
-    expect!(matches_token("2", &PathToken::Index(2))).to(be_equal_to(2));
-  }
-
-  #[test]
-  fn matches_token_test_with_index_wildcard() {
-    expect!(matches_token("$", &PathToken::StarIndex)).to(be_equal_to(0));
-    expect!(matches_token("path", &PathToken::StarIndex)).to(be_equal_to(0));
-    expect!(matches_token("*", &PathToken::StarIndex)).to(be_equal_to(0));
-    expect!(matches_token("1", &PathToken::StarIndex)).to(be_equal_to(1));
-  }
-
-  #[test]
-  fn matches_token_test_with_wildcard() {
-    expect!(matches_token("$", &PathToken::Star)).to(be_equal_to(1));
-    expect!(matches_token("path", &PathToken::Star)).to(be_equal_to(1));
-    expect!(matches_token("*", &PathToken::Star)).to(be_equal_to(1));
-    expect!(matches_token("1", &PathToken::Star)).to(be_equal_to(1));
-  }
-
-  #[test]
-  fn matches_path_matches_root_path_element() {
-    expect!(calc_path_weight("$", &vec!["$"]).0 > 0).to(be_true());
-    expect!(calc_path_weight("$", &vec![]).0 > 0).to(be_false());
-  }
-
-  #[test]
-  fn matches_path_matches_field_name() {
-    expect!(calc_path_weight("$.name", &vec!["$", "name"]).0 > 0).to(be_true());
-    expect!(calc_path_weight("$['name']", &vec!["$", "name"]).0 > 0).to(be_true());
-    expect!(calc_path_weight("$.name.other", &vec!["$", "name", "other"]).0 > 0).to(be_true());
-    expect!(calc_path_weight("$['name'].other", &vec!["$", "name", "other"]).0 > 0).to(be_true());
-    expect!(calc_path_weight("$.name", &vec!["$", "other"]).0 > 0).to(be_false());
-    expect!(calc_path_weight("$.name", &vec!["$", "name", "other"]).0 > 0).to(be_true());
-    expect!(calc_path_weight("$.other", &vec!["$", "name", "other"]).0 > 0).to(be_false());
-    expect!(calc_path_weight("$.name.other", &vec!["$", "name"]).0 > 0).to(be_false());
-  }
-
-  #[test]
-  fn matches_path_matches_array_indices() {
-    expect!(calc_path_weight("$[0]", &vec!["$", "0"]).0 > 0).to(be_true());
-    expect!(calc_path_weight("$.name[1]", &vec!["$", "name", "1"]).0 > 0).to(be_true());
-    expect!(calc_path_weight("$.name", &vec!["$", "0"]).0 > 0).to(be_false());
-    expect!(calc_path_weight("$.name[1]", &vec!["$", "name", "0"]).0 > 0).to(be_false());
-    expect!(calc_path_weight("$[1].name", &vec!["$", "name", "1"]).0 > 0).to(be_false());
-  }
-
-  #[test]
-  fn matches_path_matches_with_wildcard() {
-    expect!(calc_path_weight("$[*]", &vec!["$", "0"]).0 > 0).to(be_true());
-    expect!(calc_path_weight("$.*", &vec!["$", "name"]).0 > 0).to(be_true());
-    expect!(calc_path_weight("$.*.name", &vec!["$", "some", "name"]).0 > 0).to(be_true());
-    expect!(calc_path_weight("$.name[*]", &vec!["$", "name", "0"]).0 > 0).to(be_true());
-    expect!(calc_path_weight("$.name[*].name", &vec!["$", "name", "1", "name"]).0 > 0).to(be_true());
-    expect!(calc_path_weight("$[*]", &vec!["$", "name"]).0 > 0).to(be_false());
   }
 
   #[test]

--- a/rust/pact_models/src/message.rs
+++ b/rust/pact_models/src/message.rs
@@ -195,9 +195,9 @@ impl Message {
                   description,
                   provider_states,
                   contents: body_from_json(json, "contents", &None),
-                  matching_rules: matchers_from_json(json, &None),
+                  matching_rules: matchers_from_json(json, &None)?,
                   metadata,
-                  generators: Generators::default()
+                  generators: Generators::default(),
                 })
             },
             _ => Err(anyhow!("Messages require Pact Specification version 3"))

--- a/rust/pact_models/src/pact.rs
+++ b/rust/pact_models/src/pact.rs
@@ -97,7 +97,7 @@ pub fn load_pact_from_json(source: &str, json: &Value) -> anyhow::Result<Box<dyn
       let spec_version = determine_spec_version(source, &metadata);
       match spec_version {
         PactSpecification::V4 => v4::pact::from_json(&source, json),
-        _ => Ok(Box::new(RequestResponsePact::from_json(source, json)))
+        _ => Ok(Box::new(RequestResponsePact::from_json(source, json)?))
       }
     },
     _ => Err(anyhow!("Failed to parse Pact JSON from source '{}' - it is not a valid pact file", source))
@@ -370,6 +370,8 @@ mod tests {
   fn load_empty_pact() {
     let pact_json = r#"{}"#;
     let pact = RequestResponsePact::from_json(&"".to_string(), &serde_json::from_str(pact_json).unwrap());
+    let pact = pact.unwrap();
+
     expect!(pact.provider.name).to(be_equal_to("provider"));
     expect!(pact.consumer.name).to(be_equal_to("consumer"));
     expect!(pact.interactions.iter()).to(have_count(0));
@@ -381,6 +383,8 @@ mod tests {
   fn missing_metadata() {
     let pact_json = r#"{}"#;
     let pact = RequestResponsePact::from_json(&"".to_string(), &serde_json::from_str(pact_json).unwrap());
+    let pact = pact.unwrap();
+
     expect!(pact.specification_version).to(be_equal_to(PactSpecification::V3));
   }
 
@@ -391,6 +395,8 @@ mod tests {
         }
     }"#;
     let pact = RequestResponsePact::from_json(&"".to_string(), &serde_json::from_str(pact_json).unwrap());
+    let pact = pact.unwrap();
+
     expect!(pact.specification_version).to(be_equal_to(PactSpecification::V3));
   }
 
@@ -404,6 +410,8 @@ mod tests {
         }
     }"#;
     let pact = RequestResponsePact::from_json(&"".to_string(), &serde_json::from_str(pact_json).unwrap());
+    let pact = pact.unwrap();
+
     expect!(pact.specification_version).to(be_equal_to(PactSpecification::V3));
   }
 
@@ -417,6 +425,8 @@ mod tests {
         }
     }"#;
     let pact = RequestResponsePact::from_json(&"".to_string(), &serde_json::from_str(pact_json).unwrap());
+    let pact = pact.unwrap();
+
     expect!(pact.specification_version).to(be_equal_to(PactSpecification::Unknown));
   }
 
@@ -430,6 +440,8 @@ mod tests {
         }
     }"#;
     let pact = RequestResponsePact::from_json(&"".to_string(), &serde_json::from_str(pact_json).unwrap());
+    let pact = pact.unwrap();
+
     expect!(pact.specification_version).to(be_equal_to(PactSpecification::V1));
   }
 
@@ -443,6 +455,8 @@ mod tests {
         }
     }"#;
     let pact = RequestResponsePact::from_json(&"".to_string(), &serde_json::from_str(pact_json).unwrap());
+    let pact = pact.unwrap();
+
     expect!(pact.specification_version).to(be_equal_to(PactSpecification::Unknown));
   }
 
@@ -477,6 +491,8 @@ mod tests {
     }
     "#;
     let pact = RequestResponsePact::from_json(&"".to_string(), &serde_json::from_str(pact_json).unwrap());
+    let pact = pact.unwrap();
+
     expect!(&pact.provider.name).to(be_equal_to("Alice Service"));
     expect!(&pact.consumer.name).to(be_equal_to("Consumer"));
     expect!(pact.interactions.iter()).to(have_count(1));
@@ -546,6 +562,8 @@ mod tests {
     }
     "#;
     let pact = RequestResponsePact::from_json(&"".to_string(), &serde_json::from_str(pact_json).unwrap());
+    let pact = pact.unwrap();
+
     expect!(&pact.provider.name).to(be_equal_to("test_provider"));
     expect!(&pact.consumer.name).to(be_equal_to("test_consumer"));
     expect!(pact.metadata.iter()).to(have_count(2));
@@ -620,6 +638,8 @@ mod tests {
     }
     "#;
     let pact = RequestResponsePact::from_json(&"".to_string(), &serde_json::from_str(pact_json).unwrap());
+    let pact = pact.unwrap();
+
     expect!(&pact.provider.name).to(be_equal_to("test_provider"));
     expect!(&pact.consumer.name).to(be_equal_to("test_consumer"));
     expect!(pact.metadata.iter()).to(have_count(2));
@@ -691,6 +711,8 @@ mod tests {
     }
     "#;
     let pact = RequestResponsePact::from_json(&"".to_string(), &serde_json::from_str(pact_json).unwrap());
+    let pact = pact.unwrap();
+
     expect!(pact.interactions.iter()).to(have_count(1));
     let interaction = pact.interactions[0].clone();
     expect!(interaction.request).to(be_equal_to(Request {
@@ -721,6 +743,8 @@ mod tests {
     }
     "#;
     let pact = RequestResponsePact::from_json(&"".to_string(), &serde_json::from_str(pact_json).unwrap());
+    let pact = pact.unwrap();
+
     expect!(pact.interactions.iter()).to(have_count(1));
     let interaction = pact.interactions[0].clone();
     expect!(interaction.request).to(be_equal_to(Request {

--- a/rust/pact_models/src/response.rs
+++ b/rust/pact_models/src/response.rs
@@ -34,19 +34,20 @@ pub struct Response {
 impl Response {
 
   /// Build a `Response` from a `Value` struct.
-  pub fn from_json(response: &Value, _: &PactSpecification) -> Response {
+  pub fn from_json(response: &Value, _: &PactSpecification
+  ) -> anyhow::Result<Response> {
     let status_val = match response.get("status") {
       Some(v) => v.as_u64().unwrap() as u16,
       None => 200
     };
     let headers = headers_from_json(response);
-    Response {
+    Ok(Response {
       status: status_val,
       headers: headers.clone(),
       body: body_from_json(response, "body", &headers),
-      matching_rules:  matchers_from_json(response, &Some("responseMatchingRules".to_string())),
-      generators:  generators_from_json(response)
-    }
+      matching_rules: matchers_from_json(response, &Some("responseMatchingRules".to_string()))?,
+      generators: generators_from_json(response)?,
+    })
   }
 
   /// Returns a default response: Status 200
@@ -224,7 +225,7 @@ mod tests {
       }
      "#).unwrap();
     let response = Response::from_json(&response_json, &PactSpecification::V1_1);
-    assert_eq!(response.status, 200);
+    assert_eq!(response.unwrap().status, 200);
   }
 
   #[test]

--- a/rust/pact_models/src/tests.rs
+++ b/rust/pact_models/src/tests.rs
@@ -43,6 +43,8 @@ fn matchers_from_json_handles_missing_matchers() {
       }
      "#).unwrap();
   let matchers = matchers_from_json(&json, &Some("deprecatedName".to_string()));
+  let matchers = matchers.unwrap();
+
   expect!(matchers.rules.iter()).to(be_empty());
 }
 
@@ -57,6 +59,8 @@ fn matchers_from_json_handles_empty_matchers() {
       }
      "#).unwrap();
   let matchers = matchers_from_json(&json, &Some("deprecatedName".to_string()));
+  let matchers = matchers.unwrap();
+
   expect!(matchers.rules.iter()).to(be_empty());
 }
 
@@ -75,6 +79,8 @@ fn matchers_from_json_handles_matcher_with_no_matching_rules() {
       }
      "#).unwrap();
   let matchers = matchers_from_json(&json, &Some("deprecatedName".to_string()));
+  let matchers = matchers.unwrap();
+
   expect!(matchers).to(be_equal_to(matchingrules!{
         "body" => {
             "$.*.path" => [ ]
@@ -102,6 +108,8 @@ fn matchers_from_json_loads_matchers_correctly() {
       }
      "#).unwrap();
   let matchers = matchers_from_json(&json, &Some("deprecatedName".to_string()));
+  let matchers = matchers.unwrap();
+
   expect!(matchers).to(be_equal_to(matchingrules!{
         "body" => {
             "$.*.path" => [ MatchingRule::Regex("\\d+".to_string()) ]
@@ -129,6 +137,8 @@ fn matchers_from_json_loads_matchers_from_deprecated_name() {
       }
      "#).unwrap();
   let matchers = matchers_from_json(&json, &Some("deprecatedName".to_string()));
+  let matchers = matchers.unwrap();
+
   expect!(matchers).to(be_equal_to(matchingrules!{
         "body" => {
             "$.*.path" => [ MatchingRule::Regex(r#"\d+"#.to_string()) ]
@@ -146,6 +156,8 @@ fn generators_from_json_handles_missing_generators() {
       }
      "#).unwrap();
   let generators = generators_from_json(&json);
+  let generators = generators.unwrap();
+
   expect!(generators.categories.iter()).to(be_empty());
 }
 
@@ -160,6 +172,8 @@ fn generators_from_json_handles_empty_generators() {
       }
      "#).unwrap();
   let generators = generators_from_json(&json);
+  let generators = generators.unwrap();
+
   expect!(generators.categories.iter()).to(be_empty());
 }
 
@@ -178,6 +192,8 @@ fn generators_from_json_handles_generator_with_no_rules() {
       }
      "#).unwrap();
   let generators = generators_from_json(&json);
+  let generators = generators.unwrap();
+
   expect!(generators).to(be_equal_to(Generators::default()));
 }
 
@@ -206,6 +222,8 @@ fn generators_from_json_ignores_invalid_generators() {
       }
      "#).unwrap();
   let generators = generators_from_json(&json);
+  let generators = generators.unwrap();
+
   expect!(generators).to(be_equal_to(Generators::default()));
 }
 
@@ -231,6 +249,8 @@ fn generators_from_json_loads_generators_correctly() {
       }
      "#).unwrap();
   let generators = generators_from_json(&json);
+  let generators = generators.unwrap();
+
   expect!(generators).to(be_equal_to(generators!{
         "BODY" => {
             "$.*.path" => Generator::RandomInt(1, 10)

--- a/rust/pact_models/src/v4/async_message.rs
+++ b/rust/pact_models/src/v4/async_message.rs
@@ -110,8 +110,8 @@ impl AsynchronousMessage {
         contents: MessageContents {
           metadata,
           contents: body_from_json(&json, "contents", &as_headers),
-          matching_rules: matchers_from_json(&json, &None),
-          generators: generators_from_json(&json)
+          matching_rules: matchers_from_json(&json, &None)?,
+          generators: generators_from_json(&json)?,
         },
         comments,
         pending: json.get("pending")

--- a/rust/pact_models/src/v4/message_parts.rs
+++ b/rust/pact_models/src/v4/message_parts.rs
@@ -44,8 +44,8 @@ impl MessageContents {
       Ok(MessageContents {
         metadata,
         contents: body_from_json(&json, "contents", &as_headers),
-        matching_rules: matchers_from_json(&json, &None),
-        generators: generators_from_json(&json)
+        matching_rules: matchers_from_json(&json, &None)?,
+        generators: generators_from_json(&json)?,
       })
     } else {
       Err(anyhow!("Expected a JSON object for the message contents, got '{}'", json))

--- a/rust/pact_models/src/v4/synch_http.rs
+++ b/rust/pact_models/src/v4/synch_http.rs
@@ -93,8 +93,8 @@ impl SynchronousHttp {
         key,
         description,
         provider_states,
-        request: HttpRequest::from_json(&request),
-        response: HttpResponse::from_json(&response),
+        request: HttpRequest::from_json(&request)?,
+        response: HttpResponse::from_json(&response)?,
         comments,
         pending: json.get("pending")
           .map(|value| value.as_bool().unwrap_or_default()).unwrap_or_default()

--- a/rust/pact_verifier/src/pact_broker.rs
+++ b/rust/pact_verifier/src/pact_broker.rs
@@ -601,7 +601,8 @@ pub async fn fetch_pacts_from_broker(
                   MessagePact::from_json(&href, &pact_json)
                     .map(|pact| (pact.boxed(), None, links))
                 } else {
-                  Ok((RequestResponsePact::from_json(&href, &pact_json).boxed(), None, links))
+                  RequestResponsePact::from_json(&href, &pact_json)
+                    .map(|pact| (pact.boxed(), None, links))
                 },
                 _ => Err(anyhow!("Link '{}' does not point to a valid pact file", href))
               }
@@ -734,7 +735,10 @@ pub async fn fetch_pacts_dynamically_from_broker(
                   Err(err) => Err(PactBrokerError::ContentError(format!("{}", err)))
                 }
               } else {
-                Ok((RequestResponsePact::from_json(&href, &pact_json).boxed(), Some(context), links))
+                match RequestResponsePact::from_json(&href, &pact_json) {
+                  Ok(pact) => Ok((pact.boxed(), Some(context), links)),
+                  Err(err) => Err(PactBrokerError::ContentError(format!("{}", err)))
+                }
               },
               _ => Err(PactBrokerError::ContentError(format!("Link '{}' does not point to a valid pact file", href)))
             }


### PR DESCRIPTION
This Pull Request is in preparation for the upcoming PR about path expressions.

1. refactor: Move path expression functions into `path_exp` module
Specifically: `matches_token`, `calc_path_weight`, and `path_length`.

2. refactor: Make many JSON parsing functions fallible
This is in preparation for an upcoming change that will cause `parse_path_exp` to be called during JSON parse time.
There are now error messages for MatchingRule parsing.
Errors during MatchingRule parsing will now cause JSON parsing to fail overall, rather than just printing a warning.
Errors parsing the status code in a StatusCode matcher will also cause JSON parsing to fail overall, rather than just printing an error.

### Notice
This software was produced for the U. S. Government under Contract No. FA8702-20-C-0001, and is subject to the Rights in Noncommercial Computer Software and Noncommercial Computer Software Documentation Clause DFARS 252.227-7014 (FEB 2014)

Approved for Public Release; Distribution Unlimited. Case Number 19-3203.

(c) 2021 The MITRE Corporation. All Rights Reserved.